### PR TITLE
builder.py の system_command_path についてご報告

### DIFF
--- a/script/specs.py
+++ b/script/specs.py
@@ -89,14 +89,15 @@ def run(platform):
     # not implemented
 
 def run_iphone_simulator():
-    system_command_path = "/Library/Application\ Support/Titanium/mobilesdk/osx/" + sdk_version() + "/iphone/builder.py"
+    system_command_path = "/Library/Application Support/Titanium/mobilesdk/osx/" + sdk_version() + "/iphone/builder.py"
+    
     if os.path.exists(system_command_path):
         command_path = system_command_path
     else:
         user_command_path = "~" + system_command_path
         command_path = user_command_path
 
-    command = command_path + " run " + project_dir()
+    command = command_path.replace(" ", "\ ") + " run " + project_dir()
     os.system(command)
 
 def run_android_emulator(android_sdk_path):
@@ -104,7 +105,7 @@ def run_android_emulator(android_sdk_path):
         print "Please specify Android SDK Path."
         return False
 
-    system_command_path = "/Library/Application\ Support/Titanium/mobilesdk/osx/" + sdk_version() + "/android/builder.py"
+    system_command_path = "/Library/Application Support/Titanium/mobilesdk/osx/" + sdk_version() + "/android/builder.py"
 
     if os.path.exists(system_command_path):
         command_path = system_command_path
@@ -112,7 +113,7 @@ def run_android_emulator(android_sdk_path):
         user_command_path = "~" + system_command_path
         command_path = user_command_path
 
-    command = command_path + " run " + project_dir() + " " + android_sdk_path
+    command = command_path.replace(" ", "\ ") + " run " + project_dir() + " " + android_sdk_path
     print "Installing..."
     output = subprocess.check_output(command, shell=True)
     print output


### PR DESCRIPTION
Fixed system-comamnd-path to work for my enviroment. (osx 10.6.8 / python 2.6.1 / Titanium 1.7.2)

If you prefer to use English, Sorry for using Japanese.

akahigeg様

jasmint-titanium を公開して頂きありがとうございます。
Titanium, jasmine 共に、たった今使い始めたのですが、
当方の環境 (osx 10.6.8 / python 2.6.1 / Titanium 1.7.2)でspecs.pyコマンドが正常に動かなかったため、
発生した状況と回避コードを報告させて頂きます。
（正直、なぜ、私の環境だけ（？）でこれが発生しているのかが分かりませんが・・・）

specs.py L92 L108 あたりで、builder.py のパスをハードコードしてあります。
その際に、system_command_path にbuilder.pyファイルがあるにもかかわらず、
if os.path.exists(system_command_path) がFalseを返し、
結果として、/Users/xxx/Library/Application......以下のbuiler.pyをcommand_pathに指定することになり、
os.system(command)で、builder.pyが無いよ！と言われてしまってました。

で、原因を精査すると、
os.stat(system_command_path) がとれていない（エラーを返す）
( http://www.python.jp/doc/nightly/library/os.path.html 参照）
ことが原因のようで、もう少し調べると、"Application Support"の半角スペース部をエスケープしている
ことで、os.statがエラーを返しているようでした。
そこで、半角スペース部のエスケープを外した上で、commandを組み立てる際にエスケープを戻すよう
修正しました。

もしかしたら、当方の環境固有の原因により起こっていることかもしれませんが、
ご参考までに報告させて頂きます。

以上、よろしくお願い申し上げます。
